### PR TITLE
Add Lunar Client compatibility and F9 toggle key

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,22 +1,26 @@
 plugins {
     java
-    id("fabric-loom") version "0.12-SNAPSHOT"
+    id("fabric-loom") version "1.4-SNAPSHOT"
     id("maven-publish")
 }
 
 group = "me.m56738"
-version = "1.18.2-v1"
+version = "1.18.2-v2"
 
 dependencies {
     minecraft("com.mojang:minecraft:1.18.2")
     mappings("net.fabricmc:yarn:1.18.2+build.3:v2")
     modImplementation("net.fabricmc:fabric-loader:0.14.6")
-    modImplementation(fabricApi.module("fabric-networking-api-v1", "0.53.4+1.18.2"))
+
+    val fabricApiVersion = "0.53.4+1.18.2"
+    modImplementation(fabricApi.module("fabric-key-binding-api-v1", fabricApiVersion))
+    modImplementation(fabricApi.module("fabric-lifecycle-events-v1", fabricApiVersion))
+    modImplementation(fabricApi.module("fabric-networking-api-v1", fabricApiVersion))
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_1_8
-    targetCompatibility = JavaVersion.VERSION_1_8
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 tasks {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx4g

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/m56738/smoothcoasters/GameRendererMixinInterface.java
+++ b/src/main/java/me/m56738/smoothcoasters/GameRendererMixinInterface.java
@@ -21,4 +21,8 @@ public interface GameRendererMixinInterface extends Rotatable {
     void scSetRotationMode(RotationMode mode);
 
     void scSetRotationLimit(float minYaw, float maxYaw, float minPitch, float maxPitch);
+
+    boolean scGetRotationToggle();
+
+    void scSetRotationToggle(boolean enabled);
 }

--- a/src/main/java/me/m56738/smoothcoasters/PacketInterceptor.java
+++ b/src/main/java/me/m56738/smoothcoasters/PacketInterceptor.java
@@ -1,0 +1,18 @@
+package me.m56738.smoothcoasters;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelInboundHandlerAdapter;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+
+public class PacketInterceptor extends ChannelInboundHandlerAdapter {
+    @Override
+    public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
+        if (msg instanceof CustomPayloadS2CPacket) {
+            CustomPayloadS2CPacket packet = (CustomPayloadS2CPacket) msg;
+            if (SmoothCoasters.getInstance().handlePacket(packet)) {
+                return;
+            }
+        }
+        super.channelRead(ctx, msg);
+    }
+}

--- a/src/main/java/me/m56738/smoothcoasters/SmoothCoasters.java
+++ b/src/main/java/me/m56738/smoothcoasters/SmoothCoasters.java
@@ -1,27 +1,43 @@
 package me.m56738.smoothcoasters;
 
 import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
 import me.m56738.smoothcoasters.implementation.Implementation;
-import net.fabricmc.api.ModInitializer;
-import net.fabricmc.fabric.api.client.networking.v1.C2SPlayChannelEvents;
+import me.m56738.smoothcoasters.mixin.ClientConnectionAccessor;
+import net.fabricmc.api.ClientModInitializer;
+import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
+import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.client.option.KeyBinding;
+import net.minecraft.client.util.InputUtil;
 import net.minecraft.client.world.ClientWorld;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.packet.c2s.play.CustomPayloadC2SPacket;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Quaternion;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.lwjgl.glfw.GLFW;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 
-public class SmoothCoasters implements ModInitializer {
+public class SmoothCoasters implements ClientModInitializer {
+    private static final Logger LOG = LogManager.getLogger("SmoothCoasters");
     private static final Identifier HANDSHAKE = new Identifier("smoothcoasters", "hs");
     private static SmoothCoasters instance;
+
+    private final Map<Identifier, Implementation.PacketHandler> packetHandlers = new HashMap<>();
     private Implementation currentImplementation;
     private String version;
+    private KeyBinding toggleBinding;
+    private boolean pipelineInstalled;
 
     public static SmoothCoasters getInstance() {
         return instance;
@@ -36,44 +52,98 @@ public class SmoothCoasters implements ModInitializer {
     }
 
     @Override
-    public void onInitialize() {
+    public void onInitializeClient() {
         instance = this;
         version = FabricLoader.getInstance().getModContainer("smoothcoasters")
                 .orElseThrow(NoSuchElementException::new).getMetadata().getVersion().getFriendlyString();
 
-        C2SPlayChannelEvents.REGISTER.register((handler, sender, server, channels) -> {
-            if (channels.contains(HANDSHAKE)) {
-                ClientPlayNetworking.registerReceiver(HANDSHAKE, this::handleHandshake);
-            }
-        });
+        LOG.info("SmoothCoasters {} loaded", version);
 
-        C2SPlayChannelEvents.UNREGISTER.register((handler, sender, server, channels) -> {
-            if (channels.contains(HANDSHAKE)) {
-                reset();
-                ClientPlayNetworking.unregisterReceiver(HANDSHAKE);
-                setCurrentImplementation(null);
+        toggleBinding = KeyBindingHelper.registerKeyBinding(new KeyBinding(
+                "key.smoothcoasters.toggle.camera",
+                InputUtil.Type.KEYSYM,
+                GLFW.GLFW_KEY_F9,
+                "category.smoothcoasters"
+        ));
+
+        ClientPlayNetworking.registerGlobalReceiver(HANDSHAKE, (c, h, b, s) -> {});
+        for (String ch : new String[]{"rot", "bulk", "erot", "eprop", "rmode", "limit"}) {
+            ClientPlayNetworking.registerGlobalReceiver(new Identifier("smoothcoasters", ch), (c, h, b, s) -> {});
+        }
+
+        ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            if (client.getNetworkHandler() != null && !pipelineInstalled) {
+                installPipelineHandler(client);
+            } else if (client.getNetworkHandler() == null) {
+                pipelineInstalled = false;
+            }
+
+            while (toggleBinding.wasPressed()) {
+                boolean enabled = !getRotationToggle();
+                setRotationToggle(enabled);
+                if (enabled) {
+                    client.inGameHud.getChatHud().addMessage(new TranslatableText("smoothcoasters.camera.enabled"));
+                } else {
+                    client.inGameHud.getChatHud().addMessage(new TranslatableText("smoothcoasters.camera.disabled"));
+                }
             }
         });
     }
 
-    private void handleHandshake(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
-        byte[] versions = buf.readByteArray();
-        client.execute(() -> performHandshake(versions));
+    private void installPipelineHandler(MinecraftClient client) {
+        try {
+            Channel channel = ((ClientConnectionAccessor) client.getNetworkHandler().getConnection()).getChannel();
+            if (channel != null && channel.pipeline().get("smoothcoasters") == null) {
+                channel.pipeline().addBefore("packet_handler", "smoothcoasters", new PacketInterceptor());
+            }
+            pipelineInstalled = true;
+        } catch (Exception e) {
+            LOG.warn("Failed to install pipeline handler", e);
+            pipelineInstalled = true;
+        }
+    }
+
+    public boolean handlePacket(CustomPayloadS2CPacket packet) {
+        Identifier channel = packet.getChannel();
+        PacketByteBuf data = packet.getData();
+
+        if (channel.equals(HANDSHAKE)) {
+            byte[] versions = data.readByteArray();
+            MinecraftClient.getInstance().execute(() -> performHandshake(versions));
+            return true;
+        }
+
+        Implementation.PacketHandler handler = packetHandlers.get(channel);
+        if (handler != null) {
+            PacketByteBuf copy = new PacketByteBuf(data.copy());
+            MinecraftClient.getInstance().execute(() -> {
+                try {
+                    handler.handle(copy);
+                } finally {
+                    copy.release();
+                }
+            });
+            return true;
+        }
+
+        return false;
     }
 
     private void setCurrentImplementation(Implementation implementation) {
-        if (currentImplementation != null) {
-            currentImplementation.unregister();
-        }
-
+        packetHandlers.clear();
         currentImplementation = implementation;
 
         if (currentImplementation != null) {
             PacketByteBuf response = new PacketByteBuf(Unpooled.buffer());
             response.writeByte(currentImplementation.getVersion());
             response.writeString(version);
-            ClientPlayNetworking.send(HANDSHAKE, response);
-            currentImplementation.register();
+
+            MinecraftClient client = MinecraftClient.getInstance();
+            if (client.getNetworkHandler() != null) {
+                client.getNetworkHandler().sendPacket(new CustomPayloadC2SPacket(HANDSHAKE, response));
+            }
+
+            currentImplementation.register(packetHandlers);
         }
     }
 
@@ -90,10 +160,17 @@ public class SmoothCoasters implements ModInitializer {
     }
 
     private void performHandshake(byte[] offeredVersions) {
-        setCurrentImplementation(findImplementation(offeredVersions));
+        Implementation impl = findImplementation(offeredVersions);
+        if (impl != null) {
+            LOG.info("Negotiated protocol V{}", impl.getVersion());
+        } else {
+            LOG.warn("No compatible protocol version found");
+        }
+        setCurrentImplementation(impl);
     }
 
     public void onDisconnected() {
+        packetHandlers.clear();
         currentImplementation = null;
     }
 
@@ -133,5 +210,13 @@ public class SmoothCoasters implements ModInitializer {
     public void setRotationLimit(float minYaw, float maxYaw, float minPitch, float maxPitch) {
         ((GameRendererMixinInterface) MinecraftClient.getInstance().gameRenderer).scSetRotationLimit(
                 minYaw, maxYaw, minPitch, maxPitch);
+    }
+
+    public boolean getRotationToggle() {
+        return ((GameRendererMixinInterface) MinecraftClient.getInstance().gameRenderer).scGetRotationToggle();
+    }
+
+    public void setRotationToggle(boolean enabled) {
+        ((GameRendererMixinInterface) MinecraftClient.getInstance().gameRenderer).scSetRotationToggle(enabled);
     }
 }

--- a/src/main/java/me/m56738/smoothcoasters/implementation/ImplV1.java
+++ b/src/main/java/me/m56738/smoothcoasters/implementation/ImplV1.java
@@ -1,23 +1,14 @@
 package me.m56738.smoothcoasters.implementation;
 
 import me.m56738.smoothcoasters.SmoothCoasters;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
-import net.minecraft.network.*;
-import net.minecraft.network.listener.ClientPlayPacketListener;
+import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Quaternion;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 
-import java.io.IOException;
+import java.util.Map;
 
 public class ImplV1 implements Implementation {
-    private static final Logger LOG = LogManager.getLogger();
     private static final Identifier ROTATION = new Identifier("smoothcoasters", "rot");
-    private static final Identifier BULK = new Identifier("smoothcoasters", "bulk");
 
     protected boolean hasBulk = true;
 
@@ -27,58 +18,16 @@ public class ImplV1 implements Implementation {
     }
 
     @Override
-    public void register() {
-        ClientPlayNetworking.registerReceiver(ROTATION, this::handleRotation);
-        if (hasBulk) ClientPlayNetworking.registerReceiver(BULK, this::handleBulk);
+    public void register(Map<Identifier, PacketHandler> handlers) {
+        handlers.put(ROTATION, this::handleRotation);
     }
 
-    @Override
-    public void unregister() {
-        ClientPlayNetworking.unregisterReceiver(ROTATION);
-        if (hasBulk) ClientPlayNetworking.unregisterReceiver(BULK);
-    }
-
-    private void handleRotation(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+    private void handleRotation(PacketByteBuf buf) {
         final Quaternion rotation = new Quaternion(
                 -buf.readFloat(), -buf.readFloat(),
                 -buf.readFloat(), buf.readFloat()
         );
         final byte ticks = buf.readByte();
-        client.execute(() -> SmoothCoasters.getInstance().setRotation(rotation, ticks));
-    }
-
-    @SuppressWarnings("unchecked")
-    private void handleBulk(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
-        int count = buf.readVarInt();
-        final Packet<?>[] packets = new Packet[count];
-
-        try {
-            for (int i = 0; i < count; i++) {
-                int length = buf.readVarInt();
-                PacketByteBuf slice = new PacketByteBuf(buf.readSlice(length));
-
-                int id = slice.readVarInt();
-                Packet<?> packet = NetworkState.PLAY.getPacketHandler(NetworkSide.CLIENTBOUND, id, slice);
-
-                if (slice.isReadable()) {
-                    throw new IOException("Packet not read completely: " + id + " (" + slice.readableBytes() + " extra bytes)");
-                }
-
-                packets[i] = packet;
-            }
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
-
-        // Can't handle all at once in the main thread - some only work async
-        // As a result, packets might (rarely) be handled in different ticks
-        for (Packet<?> packet : packets) {
-            try {
-                ((Packet<ClientPlayPacketListener>) packet).apply(handler);
-            } catch (OffThreadException ignored) {
-            } catch (Throwable e) {
-                LOG.fatal("Handling bulk packet failed", e);
-            }
-        }
+        SmoothCoasters.getInstance().setRotation(rotation, ticks);
     }
 }

--- a/src/main/java/me/m56738/smoothcoasters/implementation/ImplV2.java
+++ b/src/main/java/me/m56738/smoothcoasters/implementation/ImplV2.java
@@ -1,13 +1,11 @@
 package me.m56738.smoothcoasters.implementation;
 
 import me.m56738.smoothcoasters.SmoothCoasters;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
 import net.minecraft.util.math.Quaternion;
+
+import java.util.Map;
 
 public class ImplV2 extends ImplV1 {
     private static final Identifier ENTITY_ROTATION = new Identifier("smoothcoasters", "erot");
@@ -18,24 +16,18 @@ public class ImplV2 extends ImplV1 {
     }
 
     @Override
-    public void register() {
-        super.register();
-        ClientPlayNetworking.registerReceiver(ENTITY_ROTATION, this::handleEntityRotation);
+    public void register(Map<Identifier, PacketHandler> handlers) {
+        super.register(handlers);
+        handlers.put(ENTITY_ROTATION, this::handleEntityRotation);
     }
 
-    @Override
-    public void unregister() {
-        super.unregister();
-        ClientPlayNetworking.unregisterReceiver(ENTITY_ROTATION);
-    }
-
-    private void handleEntityRotation(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+    private void handleEntityRotation(PacketByteBuf buf) {
         final int entity = buf.readInt();
         final Quaternion rotation = new Quaternion(
                 buf.readFloat(), buf.readFloat(),
                 buf.readFloat(), buf.readFloat()
         );
         final byte ticks = buf.readByte();
-        client.execute(() -> SmoothCoasters.getInstance().setEntityRotation(entity, rotation, ticks));
+        SmoothCoasters.getInstance().setEntityRotation(entity, rotation, ticks);
     }
 }

--- a/src/main/java/me/m56738/smoothcoasters/implementation/ImplV3.java
+++ b/src/main/java/me/m56738/smoothcoasters/implementation/ImplV3.java
@@ -2,12 +2,10 @@ package me.m56738.smoothcoasters.implementation;
 
 import me.m56738.smoothcoasters.RotationMode;
 import me.m56738.smoothcoasters.SmoothCoasters;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
+
+import java.util.Map;
 
 public class ImplV3 extends ImplV2 {
     private static final Identifier ENTITY_PROPERTIES = new Identifier("smoothcoasters", "eprop");
@@ -21,33 +19,22 @@ public class ImplV3 extends ImplV2 {
     }
 
     @Override
-    public void register() {
-        super.register();
-        ClientPlayNetworking.registerReceiver(ENTITY_PROPERTIES, this::handleEntityProperties);
-        if (hasRotationMode) ClientPlayNetworking.registerReceiver(ROTATION_MODE, this::handleRotationMode);
+    public void register(Map<Identifier, PacketHandler> handlers) {
+        super.register(handlers);
+        handlers.put(ENTITY_PROPERTIES, this::handleEntityProperties);
+        if (hasRotationMode) handlers.put(ROTATION_MODE, this::handleRotationMode);
     }
 
-    @Override
-    public void unregister() {
-        super.unregister();
-        ClientPlayNetworking.unregisterReceiver(ENTITY_PROPERTIES);
-        if (hasRotationMode) ClientPlayNetworking.unregisterReceiver(ROTATION_MODE);
-    }
-
-    private void handleEntityProperties(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+    private void handleEntityProperties(PacketByteBuf buf) {
         final int entity = buf.readInt();
         final byte ticks = buf.readByte();
-        client.execute(() -> {
-            if (ticks != 0) {
-                SmoothCoasters.getInstance().setEntityTicks(entity, ticks);
-            }
-        });
+        if (ticks != 0) {
+            SmoothCoasters.getInstance().setEntityTicks(entity, ticks);
+        }
     }
 
-    private void handleRotationMode(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+    private void handleRotationMode(PacketByteBuf buf) {
         final RotationMode mode = RotationMode.values()[buf.readInt()];
-        client.execute(() -> {
-            SmoothCoasters.getInstance().setRotationMode(mode);
-        });
+        SmoothCoasters.getInstance().setRotationMode(mode);
     }
 }

--- a/src/main/java/me/m56738/smoothcoasters/implementation/ImplV4.java
+++ b/src/main/java/me/m56738/smoothcoasters/implementation/ImplV4.java
@@ -2,26 +2,16 @@ package me.m56738.smoothcoasters.implementation;
 
 import me.m56738.smoothcoasters.RotationMode;
 import me.m56738.smoothcoasters.SmoothCoasters;
-import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
-import net.fabricmc.fabric.api.networking.v1.PacketSender;
-import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.network.ClientPlayNetworkHandler;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.util.Identifier;
+
+import java.util.Map;
 
 public class ImplV4 extends ImplV3 {
     private static final Identifier ROTATION_LIMIT = new Identifier("smoothcoasters", "limit");
 
     public ImplV4() {
-        // Disable deprecated features
-        // After a deprecation period, ImplV1-3 can be deleted and the remaining features can be moved into this class
-
-        // Packets contained in bulk packets bypass packet listeners, which can break stuff
-        // They are rarely used because they are hard to implement on the server side
         hasBulk = false;
-
-        // Camera mode is fundamentally broken and will be removed soon
-        // Player mode is the only remaining mode (and the default since V4)
         hasRotationMode = false;
     }
 
@@ -31,27 +21,17 @@ public class ImplV4 extends ImplV3 {
     }
 
     @Override
-    public void register() {
-        super.register();
-        ClientPlayNetworking.registerReceiver(ROTATION_LIMIT, this::handleRotationLimit);
-
-        // Camera mode is deprecated, default to player mode
+    public void register(Map<Identifier, PacketHandler> handlers) {
+        super.register(handlers);
+        handlers.put(ROTATION_LIMIT, this::handleRotationLimit);
         SmoothCoasters.getInstance().setRotationMode(RotationMode.PLAYER);
     }
 
-    @Override
-    public void unregister() {
-        super.unregister();
-        ClientPlayNetworking.unregisterReceiver(ROTATION_LIMIT);
-    }
-
-    private void handleRotationLimit(MinecraftClient client, ClientPlayNetworkHandler handler, PacketByteBuf buf, PacketSender responseSender) {
+    private void handleRotationLimit(PacketByteBuf buf) {
         final float minYaw = buf.readFloat();
         final float maxYaw = buf.readFloat();
         final float minPitch = buf.readFloat();
         final float maxPitch = buf.readFloat();
-        client.execute(() -> {
-            SmoothCoasters.getInstance().setRotationLimit(minYaw, maxYaw, minPitch, maxPitch);
-        });
+        SmoothCoasters.getInstance().setRotationLimit(minYaw, maxYaw, minPitch, maxPitch);
     }
 }

--- a/src/main/java/me/m56738/smoothcoasters/implementation/Implementation.java
+++ b/src/main/java/me/m56738/smoothcoasters/implementation/Implementation.java
@@ -1,5 +1,10 @@
 package me.m56738.smoothcoasters.implementation;
 
+import net.minecraft.network.PacketByteBuf;
+import net.minecraft.util.Identifier;
+
+import java.util.Map;
+
 public interface Implementation {
     Implementation[] IMPLEMENTATIONS = new Implementation[]{
             new ImplV4(),
@@ -10,7 +15,10 @@ public interface Implementation {
 
     byte getVersion();
 
-    void register();
+    void register(Map<Identifier, PacketHandler> handlers);
 
-    void unregister();
+    @FunctionalInterface
+    interface PacketHandler {
+        void handle(PacketByteBuf buf);
+    }
 }

--- a/src/main/java/me/m56738/smoothcoasters/mixin/ClientConnectionAccessor.java
+++ b/src/main/java/me/m56738/smoothcoasters/mixin/ClientConnectionAccessor.java
@@ -1,0 +1,12 @@
+package me.m56738.smoothcoasters.mixin;
+
+import io.netty.channel.Channel;
+import net.minecraft.network.ClientConnection;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(ClientConnection.class)
+public interface ClientConnectionAccessor {
+    @Accessor("channel")
+    Channel getChannel();
+}

--- a/src/main/java/me/m56738/smoothcoasters/mixin/CustomPayloadMixin.java
+++ b/src/main/java/me/m56738/smoothcoasters/mixin/CustomPayloadMixin.java
@@ -1,0 +1,19 @@
+package me.m56738.smoothcoasters.mixin;
+
+import me.m56738.smoothcoasters.SmoothCoasters;
+import net.minecraft.client.network.ClientPlayNetworkHandler;
+import net.minecraft.network.packet.s2c.play.CustomPayloadS2CPacket;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ClientPlayNetworkHandler.class)
+public class CustomPayloadMixin {
+    @Inject(method = "onCustomPayload", at = @At("HEAD"), cancellable = true)
+    private void onCustomPayload(CustomPayloadS2CPacket packet, CallbackInfo ci) {
+        if (SmoothCoasters.getInstance().handlePacket(packet)) {
+            ci.cancel();
+        }
+    }
+}

--- a/src/main/java/me/m56738/smoothcoasters/mixin/GameRendererMixin.java
+++ b/src/main/java/me/m56738/smoothcoasters/mixin/GameRendererMixin.java
@@ -27,11 +27,10 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
     private final DoubleQuaternion scDoubleQuaternion = new DoubleQuaternion();
     private final Quaternion scQuaternion = new Quaternion(0, 0, 0, 1);
 
-    // Local angle
     private float scLastYaw;
     private float scYaw;
     private float scPitch;
-    private boolean scHasLimit = false;
+    private boolean scHasLimit;
     private float scMinYaw = -180;
     private float scMaxYaw = 180;
     private float scMinPitch = -90;
@@ -40,6 +39,7 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
     private boolean scSuppressChanges;
     private RotationMode scRotationMode = RotationMode.CAMERA;
     private boolean scActive;
+    private boolean scToggle = true;
 
     @Shadow
     @Final
@@ -54,11 +54,10 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
         scPose.set(rotation, ticks);
         scPose.calculate(scPoseDoubleQuaternion, 0);
         scPoseDoubleQuaternion.conjugate();
-        scActive = scPose.isActive();
+        scActive = scToggle && scPose.isActive();
         if (scActive && ticks == 0) {
             ClientPlayerEntity player = client.player;
             if (player != null) {
-                // Update local yaw/pitch so the player still looks in the same direction
                 scUpdateRotation(player);
             }
         }
@@ -83,22 +82,11 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
         if (!scHasLimit) return;
         scYaw = MathHelper.wrapDegrees(scYaw);
         scPitch = MathHelper.wrapDegrees(scPitch);
-        if (scYaw < scMinYaw) {
-            scYaw = scMinYaw;
-        }
-        if (scYaw > scMaxYaw) {
-            scYaw = scMaxYaw;
-        }
-        if (scPitch < scMinPitch) {
-            scPitch = scMinPitch;
-        }
-        if (scPitch > scMaxPitch) {
-            scPitch = scMaxPitch;
-        }
+        scYaw = MathHelper.clamp(scYaw, scMinYaw, scMaxYaw);
+        scPitch = MathHelper.clamp(scPitch, scMinPitch, scMaxPitch);
     }
 
     private void scApplyLocalRotation() {
-        // Server-supplied rotation (excluding local player rotation)
         scPose.calculate(scPoseDoubleQuaternion, client.getTickDelta());
         scPoseDoubleQuaternion.toQuaternion(scPoseQuaternion);
         scPoseDoubleQuaternion.conjugate();
@@ -112,14 +100,12 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
             return;
         }
 
-        // Add the local yaw/pitch
         scDoubleQuaternion.set(scPoseDoubleQuaternion);
         scDoubleQuaternion.rotateY(-scYaw);
         scDoubleQuaternion.rotateX(scPitch);
         scDoubleQuaternion.toQuaternion(scQuaternion);
         scQuaternion.conjugate();
 
-        // Compute the result yaw/pitch
         Vector3d forward = scDoubleQuaternion.getForwardVector();
         Vector3d up = scDoubleQuaternion.getUpVector();
         float yaw = DoubleQuaternion.getYaw(forward, up);
@@ -134,7 +120,6 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
         }
         scLastYaw = yaw;
 
-        // Apply the result to the player
         scSuppressChanges = true;
         player.prevHeadYaw = yaw;
         player.prevYaw = yaw;
@@ -153,7 +138,6 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
 
         ClientPlayerEntity player = (ClientPlayerEntity) entity;
 
-        // Difference from pose to desired look direction
         DoubleQuaternion difference = new DoubleQuaternion();
         difference.set(scPoseDoubleQuaternion);
         difference.conjugate();
@@ -171,8 +155,6 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
         if (scRotationMode != RotationMode.PLAYER || !(entity instanceof ClientPlayerEntity) || !scActive) {
             return;
         }
-        // Set entity to local rotation
-        // Suppress changes for mouse movement
         scSuppressChanges = true;
         entity.setYaw(scYaw);
         entity.setPitch(scPitch);
@@ -183,11 +165,28 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
         if (scRotationMode != RotationMode.PLAYER || !(entity instanceof ClientPlayerEntity) || !scActive) {
             return;
         }
-        // Store new local rotation
         scYaw = entity.getYaw();
         scPitch = entity.getPitch();
         scEnforceRotationLimit();
         scApplyLocalRotation();
+    }
+
+    @Override
+    public boolean scGetRotationToggle() {
+        return scToggle;
+    }
+
+    @Override
+    public void scSetRotationToggle(boolean enabled) {
+        scPose.calculate(scPoseDoubleQuaternion, 0);
+        scToggle = enabled;
+        scActive = scToggle && scPose.isActive();
+        if (scActive) {
+            ClientPlayerEntity player = client.player;
+            if (player != null) {
+                scUpdateRotation(player);
+            }
+        }
     }
 
     @Inject(method = "reset", at = @At("HEAD"))
@@ -198,7 +197,7 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
     @Inject(method = "tick", at = @At("HEAD"))
     private void tick(CallbackInfo info) {
         scPose.tick();
-        scActive = scPose.isActive();
+        scActive = scToggle && scPose.isActive();
     }
 
     @Inject(method = "render", at = @At(value = "HEAD"))
@@ -211,21 +210,21 @@ public abstract class GameRendererMixin implements GameRendererMixinInterface {
 
     @Inject(method = "renderWorld", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/render/WorldRenderer;setupFrustum(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/util/math/Vec3d;Lnet/minecraft/util/math/Matrix4f;)V"))
     private void renderWorld(float tickDelta, long limitTime, MatrixStack matrix, CallbackInfo info) {
-        if (camera.getFocusedEntity() != client.player || !scActive) {
+        if (!scActive || camera.getFocusedEntity() != client.player) {
             return;
         }
 
         if (scRotationMode == RotationMode.PLAYER) {
             Perspective perspective = client.options.getPerspective();
-            matrix.loadIdentity(); // Don't use the player's yaw/pitch (the quaternion below already contains it)
+            matrix.loadIdentity();
             if (perspective.isFirstPerson() || !perspective.isFrontView()) {
                 matrix.multiply(Vec3f.POSITIVE_Y.getDegreesQuaternion(180));
             }
-            matrix.multiply(scQuaternion); // Apply the rotation (server-supplied + local)
+            matrix.multiply(scQuaternion);
         } else if (scRotationMode == RotationMode.CAMERA) {
             Perspective perspective = client.options.getPerspective();
             if (perspective.isFirstPerson()) {
-                matrix.multiply(scPoseQuaternion); // Add the server-supplied rotation
+                matrix.multiply(scPoseQuaternion);
             }
         }
     }

--- a/src/main/resources/assets/smoothcoasters/lang/en_us.json
+++ b/src/main/resources/assets/smoothcoasters/lang/en_us.json
@@ -1,0 +1,6 @@
+{
+    "category.smoothcoasters": "SmoothCoasters",
+    "key.smoothcoasters.toggle.camera": "Toggle Camera Rotation",
+    "smoothcoasters.camera.enabled": "[SmoothCoasters] Camera rotation enabled",
+    "smoothcoasters.camera.disabled": "[SmoothCoasters] Camera rotation disabled"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -7,7 +7,7 @@
     "environment": "client",
     "license": "MIT",
     "entrypoints": {
-        "main": [
+        "client": [
             "me.m56738.smoothcoasters.SmoothCoasters"
         ]
     },
@@ -24,6 +24,8 @@
     ],
     "depends": {
         "fabricloader": "*",
+        "fabric-key-binding-api-v1": "*",
+        "fabric-lifecycle-events-v1": "*",
         "fabric-networking-api-v1": "*",
         "minecraft": "*"
     },

--- a/src/main/resources/smoothcoasters.mixins.json
+++ b/src/main/resources/smoothcoasters.mixins.json
@@ -2,10 +2,12 @@
     "required": true,
     "minVersion": "0.8",
     "package": "me.m56738.smoothcoasters.mixin",
-    "compatibilityLevel": "JAVA_8",
+    "compatibilityLevel": "JAVA_17",
     "mixins": [
         "ArmorStandEntityMixin",
         "ArmorStandEntityModelMixin",
+        "ClientConnectionAccessor",
+        "CustomPayloadMixin",
         "DebugHudMixin",
         "EntityMixin",
         "EntityRenderDispatcherMixin",


### PR DESCRIPTION
Lunar Client bypasses Fabric's networking API for custom payload packets, so the handshake and rotation packets were never received. This adds a Netty pipeline handler that intercepts packets before they reach the client's modified handler, while still using Fabric API for channel registration so the server knows we support smoothcoasters.

Also backports the camera rotation toggle key (F9) from newer versions, updates build tooling (Gradle 8.5, Loom 1.4, Java 17), and switches to ClientModInitializer.

vibe coded for personal use, prolly not perfect but it works

Closes #16 