### PR TITLE
Fix passenger positioning during teleportion when SmoothCoasters is active

### DIFF
--- a/src/main/java/me/m56738/smoothcoasters/mixin/EntityMixin.java
+++ b/src/main/java/me/m56738/smoothcoasters/mixin/EntityMixin.java
@@ -5,10 +5,12 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.Minecraft;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.phys.Vec3;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Entity.class)
 @Environment(EnvType.CLIENT)
@@ -33,6 +35,20 @@ public class EntityMixin {
 
     @Inject(method = "turn", at = @At("RETURN"))
     private void turnTail(double cursorDeltaX, double cursorDeltaY, CallbackInfo info) {
+        ((GameRendererMixinInterface) Minecraft.getInstance().gameRenderer)
+                .smoothcoasters$applyLocalRotation((Entity) (Object) this);
+    }
+
+    @Inject(method = "getVehicleAttachmentPoint", at = @At("HEAD"))
+    private void getVehicleAttachmentPointHead(Entity vehicle, CallbackInfoReturnable<Vec3> info) {
+        // Attachment points must use the local look direction. The composed
+        // coaster yaw can otherwise offset the player during vehicle movement.
+        ((GameRendererMixinInterface) Minecraft.getInstance().gameRenderer)
+                .smoothcoasters$loadLocalRotation((Entity) (Object) this);
+    }
+
+    @Inject(method = "getVehicleAttachmentPoint", at = @At("RETURN"))
+    private void getVehicleAttachmentPointTail(Entity vehicle, CallbackInfoReturnable<Vec3> info) {
         ((GameRendererMixinInterface) Minecraft.getInstance().gameRenderer)
                 .smoothcoasters$applyLocalRotation((Entity) (Object) this);
     }


### PR DESCRIPTION
Fixes #18 

Temporarily applies the player's local look rotation while vanilla calculates getVehicleAttachmentPoint, then restores the composed SmoothCoasters rotation.

This prevents ride vehicle teleports and seat transitions from offsetting the player position while preserving the intended camera and player-facing rotation.

AI was used to create this patch, That said, I've allowed edits by maintainers so feel free to make changes where needed.